### PR TITLE
Naming a few boost related variables

### DIFF
--- a/src/engine/fox_play.c
+++ b/src/engine/fox_play.c
@@ -4949,8 +4949,8 @@ void Player_UpdateTankRoll(Player* player) {
 }
 
 void Player_ArwingBoost(Player* player) {
-    f32 sp2C;
-    f32 sp28;
+    f32 boostRecoverRate;
+    f32 boostDepleteRate;
     s32 stickY;
 
     if ((player->boostMeter != 0.0f) && (gInputHold->button & gBrakeButton[player->num]) &&
@@ -4959,12 +4959,12 @@ void Player_ArwingBoost(Player* player) {
     }
 
     if (gLevelMode == LEVELMODE_ON_RAILS) {
-        sp28 = 3.0f;
-        sp2C = 0.5f;
+        boostDepleteRate = 3.0f;
+        boostRecoverRate = 0.5f;
 
     } else {
-        sp28 = 1.5f;
-        sp2C = 0.35f;
+        boostDepleteRate = 1.5f;
+        boostRecoverRate = 0.35f;
     }
 
     player->sfx.boost = 0;
@@ -5044,7 +5044,7 @@ void Player_ArwingBoost(Player* player) {
                 Math_SmoothStepToF(&player->arwing.upperLeftFlapYrot, 0.0f, 0.5f, 100.0f, 0.0f);
                 Math_SmoothStepToF(&player->arwing.bottomLeftFlapYrot, 0.0f, 0.5f, 100.0f, 0.0f);
             }
-            player->boostMeter += sp28;
+            player->boostMeter += boostDepleteRate;
             if (player->boostMeter > 90.0f) {
                 player->boostMeter = 90.0f;
                 player->boostCooldown = true;
@@ -5063,7 +5063,7 @@ void Player_ArwingBoost(Player* player) {
             Math_SmoothStepToF(&D_ctx_801779A8[player->num], 50.0f, 1.0f, 10.0f, 0.0f);
         } else {
             if (player->boostMeter > 0.0f) {
-                player->boostMeter -= sp2C;
+                player->boostMeter -= boostRecoverRate;
                 if (player->boostMeter <= 0.0f) {
                     player->boostMeter = 0.0f;
                     player->boostCooldown = false;
@@ -5085,16 +5085,16 @@ void Player_ArwingBoost2(Player* player) {
 }
 
 void Player_ArwingBrake(Player* player) {
-    f32 sp34;
-    f32 sp30;
+    f32 brakeRecoverRate;
+    f32 brakeDepleteRate;
     s32 stickY;
 
     if (gLevelMode == LEVELMODE_ON_RAILS) {
-        sp30 = 3.0f;
-        sp34 = 0.5f;
+        brakeDepleteRate = 3.0f;
+        brakeRecoverRate = 0.5f;
     } else {
-        sp30 = 1.5f;
-        sp34 = 0.35f;
+        brakeDepleteRate = 1.5f;
+        brakeRecoverRate = 0.35f;
     }
 
     player->sfx.brake = false;
@@ -5143,7 +5143,7 @@ void Player_ArwingBrake(Player* player) {
             Math_SmoothStepToF(&player->arwing.bottomLeftFlapYrot, -90.0f, 0.2f, 100.0f, 0.0f);
         }
 
-        player->boostMeter += sp30;
+        player->boostMeter += brakeDepleteRate;
         if (player->boostMeter > 90.0f) {
             player->boostCooldown = true;
             player->boostMeter = 90.0f;
@@ -5159,7 +5159,7 @@ void Player_ArwingBrake(Player* player) {
         player->sfx.brake = true;
         Math_SmoothStepToF(&D_ctx_801779A8[player->num], 25.0f, 1.0f, 5.0f, 0.0f);
     } else if (player->boostMeter > 0.0f) {
-        player->boostMeter -= sp34;
+        player->boostMeter -= brakeRecoverRate;
         if (player->boostMeter <= 0.0f) {
             player->boostMeter = 0.0f;
             player->boostCooldown = false;

--- a/src/engine/fox_tank.c
+++ b/src/engine/fox_tank.c
@@ -15,7 +15,7 @@ u8 D_800C9F04 = 0;
 u8 D_800C9F08 = 0;
 s32 D_800C9F0C = 0; // unused.
 f32 D_800C9F10 = 0.0f;
-s32 activeBurnerCount = 0;
+s32 gTankActiveBurnerCount = 0;
 s32 D_800C9F18[2] = { 0, 0 }; // unused.
 f32 D_800C9F20 = 0.0f;
 f32 D_800C9F24 = 0.0f;
@@ -549,7 +549,7 @@ void func_tank_80045348(Player* player) {
 
     if (player->unk_19C >= 0) {
         if ((gBoostButton[player->num] & gInputHold->button) && !player->boostCooldown) {
-            activeBurnerCount++;
+            gTankActiveBurnerCount++;
             sp2E = true;
             if (D_800C9F24 == 0.0f) {
                 player->unk_190 = player->unk_194 = 4.0f;
@@ -572,7 +572,7 @@ void func_tank_80045348(Player* player) {
             D_800C9F24 = 0.0f;
         }
         if ((gBrakeButton[player->num] & gInputHold->button) && !player->boostCooldown && !sp2E) {
-            activeBurnerCount++;
+            gTankActiveBurnerCount++;
             baseSpeedTarget = 5.0f;
             sp40 = 100.0f;
             sp3C = 0.2f;
@@ -599,7 +599,7 @@ void func_tank_80045678(Player* player) {
         Audio_KillSfxBySourceAndId(player->sfxSource, NA_SE_TANK_SLIDE);
     }
     if ((gInputHold->button & Z_TRIG) && !player->boostCooldown) {
-        activeBurnerCount++;
+        gTankActiveBurnerCount++;
         if (D_800C9F20 == 0.0f) {
             AUDIO_PLAY_SFX(NA_SE_TANK_BURNER_HALF, player->sfxSource, 0);
         }
@@ -629,7 +629,7 @@ void func_tank_80045678(Player* player) {
         Audio_KillSfxBySourceAndId(player->sfxSource, NA_SE_TANK_SLIDE);
     }
     if ((gInputHold->button & R_TRIG) && !player->boostCooldown) {
-        activeBurnerCount++;
+        gTankActiveBurnerCount++;
         if (player->unk_2C0 == 0.0f) {
             AUDIO_PLAY_SFX(NA_SE_TANK_BURNER_HALF, player->sfxSource, 0);
         }
@@ -1115,12 +1115,12 @@ void Tank_UpdateOnRails(Player* player) {
 
     player->wingPosition = 1;
     func_tank_80045130(player);
-    activeBurnerCount = 0;
+    gTankActiveBurnerCount = 0;
     func_tank_80045678(player);
     func_tank_80045348(player);
     if (!player->boostCooldown) {
-        if (activeBurnerCount != 0) {
-            if (activeBurnerCount >= 2) {
+        if (gTankActiveBurnerCount != 0) {
+            if (gTankActiveBurnerCount >= 2) {
                 player->boostMeter += 2.0f;
             } else {
                 player->boostMeter += 1.0f;

--- a/src/engine/fox_tank.c
+++ b/src/engine/fox_tank.c
@@ -15,7 +15,7 @@ u8 D_800C9F04 = 0;
 u8 D_800C9F08 = 0;
 s32 D_800C9F0C = 0; // unused.
 f32 D_800C9F10 = 0.0f;
-s32 D_800C9F14 = 0;
+s32 activeBurnerCount = 0;
 s32 D_800C9F18[2] = { 0, 0 }; // unused.
 f32 D_800C9F20 = 0.0f;
 f32 D_800C9F24 = 0.0f;
@@ -549,7 +549,7 @@ void func_tank_80045348(Player* player) {
 
     if (player->unk_19C >= 0) {
         if ((gBoostButton[player->num] & gInputHold->button) && !player->boostCooldown) {
-            D_800C9F14++;
+            activeBurnerCount++;
             sp2E = true;
             if (D_800C9F24 == 0.0f) {
                 player->unk_190 = player->unk_194 = 4.0f;
@@ -572,7 +572,7 @@ void func_tank_80045348(Player* player) {
             D_800C9F24 = 0.0f;
         }
         if ((gBrakeButton[player->num] & gInputHold->button) && !player->boostCooldown && !sp2E) {
-            D_800C9F14++;
+            activeBurnerCount++;
             baseSpeedTarget = 5.0f;
             sp40 = 100.0f;
             sp3C = 0.2f;
@@ -599,7 +599,7 @@ void func_tank_80045678(Player* player) {
         Audio_KillSfxBySourceAndId(player->sfxSource, NA_SE_TANK_SLIDE);
     }
     if ((gInputHold->button & Z_TRIG) && !player->boostCooldown) {
-        D_800C9F14++;
+        activeBurnerCount++;
         if (D_800C9F20 == 0.0f) {
             AUDIO_PLAY_SFX(NA_SE_TANK_BURNER_HALF, player->sfxSource, 0);
         }
@@ -629,7 +629,7 @@ void func_tank_80045678(Player* player) {
         Audio_KillSfxBySourceAndId(player->sfxSource, NA_SE_TANK_SLIDE);
     }
     if ((gInputHold->button & R_TRIG) && !player->boostCooldown) {
-        D_800C9F14++;
+        activeBurnerCount++;
         if (player->unk_2C0 == 0.0f) {
             AUDIO_PLAY_SFX(NA_SE_TANK_BURNER_HALF, player->sfxSource, 0);
         }
@@ -1115,12 +1115,12 @@ void Tank_UpdateOnRails(Player* player) {
 
     player->wingPosition = 1;
     func_tank_80045130(player);
-    D_800C9F14 = 0;
+    activeBurnerCount = 0;
     func_tank_80045678(player);
     func_tank_80045348(player);
     if (!player->boostCooldown) {
-        if (D_800C9F14 != 0) {
-            if (D_800C9F14 >= 2) {
+        if (activeBurnerCount != 0) {
+            if (activeBurnerCount >= 2) {
                 player->boostMeter += 2.0f;
             } else {
                 player->boostMeter += 1.0f;

--- a/src/engine/fox_tank.c
+++ b/src/engine/fox_tank.c
@@ -15,7 +15,7 @@ u8 D_800C9F04 = 0;
 u8 D_800C9F08 = 0;
 s32 D_800C9F0C = 0; // unused.
 f32 D_800C9F10 = 0.0f;
-s32 gTankActiveBurnerCount = 0;
+s32 sTankActiveBurnerCount = 0;
 s32 D_800C9F18[2] = { 0, 0 }; // unused.
 f32 D_800C9F20 = 0.0f;
 f32 D_800C9F24 = 0.0f;
@@ -549,7 +549,7 @@ void func_tank_80045348(Player* player) {
 
     if (player->unk_19C >= 0) {
         if ((gBoostButton[player->num] & gInputHold->button) && !player->boostCooldown) {
-            gTankActiveBurnerCount++;
+            sTankActiveBurnerCount++;
             sp2E = true;
             if (D_800C9F24 == 0.0f) {
                 player->unk_190 = player->unk_194 = 4.0f;
@@ -572,7 +572,7 @@ void func_tank_80045348(Player* player) {
             D_800C9F24 = 0.0f;
         }
         if ((gBrakeButton[player->num] & gInputHold->button) && !player->boostCooldown && !sp2E) {
-            gTankActiveBurnerCount++;
+            sTankActiveBurnerCount++;
             baseSpeedTarget = 5.0f;
             sp40 = 100.0f;
             sp3C = 0.2f;
@@ -599,7 +599,7 @@ void func_tank_80045678(Player* player) {
         Audio_KillSfxBySourceAndId(player->sfxSource, NA_SE_TANK_SLIDE);
     }
     if ((gInputHold->button & Z_TRIG) && !player->boostCooldown) {
-        gTankActiveBurnerCount++;
+        sTankActiveBurnerCount++;
         if (D_800C9F20 == 0.0f) {
             AUDIO_PLAY_SFX(NA_SE_TANK_BURNER_HALF, player->sfxSource, 0);
         }
@@ -629,7 +629,7 @@ void func_tank_80045678(Player* player) {
         Audio_KillSfxBySourceAndId(player->sfxSource, NA_SE_TANK_SLIDE);
     }
     if ((gInputHold->button & R_TRIG) && !player->boostCooldown) {
-        gTankActiveBurnerCount++;
+        sTankActiveBurnerCount++;
         if (player->unk_2C0 == 0.0f) {
             AUDIO_PLAY_SFX(NA_SE_TANK_BURNER_HALF, player->sfxSource, 0);
         }
@@ -1115,12 +1115,12 @@ void Tank_UpdateOnRails(Player* player) {
 
     player->wingPosition = 1;
     func_tank_80045130(player);
-    gTankActiveBurnerCount = 0;
+    sTankActiveBurnerCount = 0;
     func_tank_80045678(player);
     func_tank_80045348(player);
     if (!player->boostCooldown) {
-        if (gTankActiveBurnerCount != 0) {
-            if (gTankActiveBurnerCount >= 2) {
+        if (sTankActiveBurnerCount != 0) {
+            if (sTankActiveBurnerCount >= 2) {
                 player->boostMeter += 2.0f;
             } else {
                 player->boostMeter += 1.0f;


### PR DESCRIPTION
For more clarity about `gTankActiveBurnerCount`: Each of the following actions increments the value if they are happening during the frame: Player is boosting, player is braking, player is using the left jet (holding Z), player is using the right jet (holding R). 
This value is used to determine how fast the boost meter should be drained. 