### PR TITLE
Fix error when loading Aquas map when compiled with GCC

### DIFF
--- a/include/sf64thread.h
+++ b/include/sf64thread.h
@@ -120,7 +120,11 @@ extern u8 gSerialThreadStack[0x1000]; // 800E0FB0
 extern SPTask* gCurrentTask;
 extern SPTask* sAudioTasks[1];
 extern SPTask* sGfxTasks[2];
+#ifdef AVOID_UB
+extern SPTask* sNewAudioTasks[2];
+#else
 extern SPTask* sNewAudioTasks[1];
+#endif
 extern SPTask* sNewGfxTasks[2];
 extern u32 gSegments[16]; // 800E1FD0
 extern OSMesgQueue gPiMgrCmdQueue; // 800E2010

--- a/src/sys/sys_main.c
+++ b/src/sys/sys_main.c
@@ -6,7 +6,11 @@ s32 sGammaMode = 1;
 SPTask* gCurrentTask;
 SPTask* sAudioTasks[1];
 SPTask* sGfxTasks[2];
+#ifdef AVOID_UB
+SPTask* sNewAudioTasks[2];
+#else
 SPTask* sNewAudioTasks[1];
+#endif
 SPTask* sNewGfxTasks[2];
 u32 gSegments[16];          // 800E1FD0
 OSMesgQueue gPiMgrCmdQueue; // 800E2010


### PR DESCRIPTION
Hello guys! First of all thanks for creating this project. I have played this a lot as a kid and is very interesting to see how things were done, and also be able to do your own changes.
I noticed that when compiling with GCC, the Aquas map wasn't loading. After some debugging I found out that, two audio tasks are scheduled, only on GCC, causing the second audio task to overwrite the Gfx tasks buffer.
In this PR I have added a safeguard to prevent this. Not sure if it's the best fix. But it worked 😅