### PR TITLE
Add ISVIEWER support

### DIFF
--- a/include/mods.h
+++ b/include/mods.h
@@ -59,7 +59,7 @@
 /**
  * Spawner:
  * Spawn Scenery, Actors, Bosses, Sprites, Items, Effects and even Event Actors.
- * 
+ *
  * Controls:
  * D-Pad left and right to set the object Id.
  * C-Right to change between spawn modes.
@@ -70,6 +70,12 @@
  * WARNING: Spawning an object that's not loaded in memory will likely result in a crash.
  */
 #define MODS_SPAWNER 0
+
+/**
+ * IS Viewer:
+ * Allows to use osSyncPrintf to print debug messages to the console on emulators that support it.
+ */
+#define MODS_ISVIEWER 0
 
 /* ************************* */
 
@@ -87,6 +93,10 @@ void RamMod_Update(void);
 
 #if MODS_SPAWNER == 1
 void Spawner(void);
+#endif
+
+#if MODS_ISVIEWER == 1
+void ISViewer_Init(void);
 #endif
 
 #endif

--- a/src/mods/isviewer.c
+++ b/src/mods/isviewer.c
@@ -1,0 +1,81 @@
+#include "PR/xstdio.h"
+#include "PR/rcp.h"
+#include "libc/stdarg.h"
+
+// Most of the code here is from libdragon https://github.com/DragonMinded/libdragon/blob/trunk/src/debug.c
+// with small changes to make it work with libultra
+
+/** ISViewer register for magic value (to check ISViewer presence) */
+#define ISVIEWER_MAGIC 0x13FF0000
+/** ISViewer register for circular buffer write pointer */
+#define ISVIEWER_WRITE_POINTER 0x13FF0014
+/** ISViewer buffer */
+#define ISVIEWER_BUFFER 0x13FF0020
+/** ISViewer buffer length */
+#define ISVIEWER_BUFFER_LEN 0x00000200 // Buffer size is configurable on real ISViewer, it's usually 64kB - 0x20
+
+static u8 sISViewerInitialized = 0;
+
+void ISViewer_Init(void) {
+    // To check whether an ISViewer is present (probably emulated),
+    // write some data to the "magic" register. If we can read it
+    // back, it means that there's some memory there and we can
+    // hopefully use it.
+
+    // Magic value is different than what official ISViewer code used, but since
+    // libdragon doesn't implement correct access pattern (circular buffer)
+    // we want to differentiate our implementation from the real thing
+    const u32 magic = 0x12345678;
+
+    // Write inverted magic value to check if the memory is truly writable,
+    // and to make sure there's no residual value that's equal to our magic value
+    IO_WRITE(ISVIEWER_MAGIC, ~magic);
+    if (IO_READ(ISVIEWER_MAGIC) != ~magic) {
+        sISViewerInitialized = 0;
+        return;
+    }
+
+    IO_WRITE(ISVIEWER_MAGIC, magic);
+    sISViewerInitialized = IO_READ(ISVIEWER_MAGIC) == magic;
+}
+
+static void ISViewer_Write(const u8* data, int len) {
+    int i;
+    while (len > 0) {
+        u32 l = len < ISVIEWER_BUFFER_LEN ? len : ISVIEWER_BUFFER_LEN;
+
+        // Write 32-bit aligned words to copy the buffer. Notice that
+        // we might overflow the input buffer if it's not a multiple
+        // of 4 bytes but it doesn't matter because we are going to
+        // write the exact number of bytes later.
+        for (i = 0; i < l; i += 4) {
+            u32 value = ((u32) data[0] << 24) | ((u32) data[1] << 16) | ((u32) data[2] << 8) | ((u32) data[3] << 0);
+            IO_WRITE(ISVIEWER_BUFFER + i, value);
+            data += 4;
+        }
+
+        // Flush the data into the ISViewer
+        // We use write pointer register as length register,
+        // but that's fine for emulators that usually doesn't
+        // update the read and write pointers anyways.
+        IO_WRITE(ISVIEWER_WRITE_POINTER, l);
+        len -= l;
+    }
+}
+
+static char* ISViwer_ProutPrintf(char* arg, const char* str, size_t count) {
+    ISViewer_Write(str, count);
+    return 1;
+}
+
+void osSyncPrintf(const char* fmt, ...) {
+    va_list args;
+
+    if (!sISViewerInitialized) {
+        return;
+    }
+
+    va_start(args, fmt);
+    _Printf(ISViwer_ProutPrintf, NULL, fmt, args);
+    va_end(args);
+}

--- a/src/sys/sys_main.c
+++ b/src/sys/sys_main.c
@@ -1,5 +1,6 @@
 #include "sys.h"
 #include "sf64audio_external.h"
+#include "mods.h"
 
 s32 sGammaMode = 1;
 
@@ -490,8 +491,15 @@ void Idle_ThreadEntry(void* arg0) {
 void bootproc(void) {
     RdRam_CheckIPL3();
     osInitialize();
+#if MODS_ISVIEWER == 1
+    ISViewer_Init();
+#endif
     Main_Initialize();
     osCreateThread(&sIdleThread, THREAD_ID_IDLE, &Idle_ThreadEntry, NULL, sIdleThreadStack + sizeof(sIdleThreadStack),
                    255);
     osStartThread(&sIdleThread);
 }
+
+#if MODS_ISVIEWER == 1
+#include "../mods/isviewer.c"
+#endif


### PR DESCRIPTION
When the flag `MODS_ISVIEWER` is enabled you can use `osSyncPrintf` to print messages to the terminal on emulators that support this feature. I personally use Ares emulator and it works there.
The code used is part of libdragon with small modifications to make it work with libultra.